### PR TITLE
Get rid of spurious cmp in definition.

### DIFF
--- a/lib/LaTeXML/Package/statements.sty.ltxml
+++ b/lib/LaTeXML/Package/statements.sty.ltxml
@@ -159,7 +159,7 @@ sub definitionBody {
       $doc->openElement('dc:title');
       $doc->absorb($title);
       $doc->closeElement('dc:title');}
-    $doc->openElement('omdoc:CMP');
+   if ($doc->isCloseable('omdoc:CMP')) { $doc->openElement('omdoc:CMP'); }
    $doc->absorb($props{body}) if $props{body};
    $doc->maybeCloseElement('omdoc:CMP');
     if ($props{theory}) {


### PR DESCRIPTION
See #52 .