### PR TITLE
Inlinedef fix

### DIFF
--- a/lib/LaTeXML/Package/statements.sty.ltxml
+++ b/lib/LaTeXML/Package/statements.sty.ltxml
@@ -290,7 +290,7 @@ DefConstructor('\inlinedef OptionalKeyVals:omtext {}', sub {
  my @symbols = @{$props{defs} || []};
  #Prepare for symbol insertion -insert before the parent of the closest ancestor CMP element
  my $original_node = $document->getNode;
- my $statement_ancestor = $document->findnode('../omdoc:omtext[1] | ../omdoc:assertion[1] | ../omdoc:axiom[1]', $original_node);
+ my $statement_ancestor = $document->findnode('ancestor::omdoc:omtext[1] | ancestor::omdoc:assertion[1] | ancestor::omdoc:axiom[1]', $original_node);
  foreach my $symb(@symbols) {
    next if $for_attr{$symb};
    $for_attr{$symb}=1;


### PR DESCRIPTION
Fix for #37 . The following is the output for ` MathHub/MiKoMH/GenCS/latexml/encryption/en/public-key-encryption.tex`. I also ran it for other some other modules that contain `\inlinedef` which had no such error anymore. 

Can be merged to be tested on more repositories.

```tex
 \inlinedef{A \defii{digital}{signature} consists of a plaintext together with
            its ciphertext -- encoded with the sender's private key}.  A message signed
          with a sender's private key can be verified by anyone who has access to the
          sender's public key, thereby proving that the sender had access to the private
          key (and therefore is likely to be the person associated with the public key
          used), and the part of the message that has not been tampered with.
```
```xml
<symbol xmlns="" name="digital-signature" xml:id="digital-signature.def.sym"/>
<omdoc:omtext xml:id="I1.i1.omtext1" about="#I1.i1.omtext1" stex:srcref="/Users/Hang/lmh/localmh/MathHub/MiKoMH/GenCS/source/encryption/en/public-key-encryption.tex#textrange(from=8;0,to=22;16)">
  <omdoc:metadata xml:id="I1.i1.omtext1.metadata1" about="#I1.i1.omtext1.metadata1" stex:srcref="/Users/Hang/lmh/localmh/MathHub/MiKoMH/GenCS/source/encryption/en/public-key-encryption.tex#textrange(from=8;0,to=22;16)">
  <dc:title xml:id="I1.i1.omtext1.metadata1.title1" about="#I1.i1.omtext1.metadata1.title1" stex:srcref="/Users/Hang/lmh/localmh/MathHub/MiKoMH/GenCS/source/encryption/en/public-key-encryption.tex#textrange(from=8;0,to=22;16)">
    Application: Digital Signatures
  </dc:title>
</omdoc:metadata>
<omdoc:CMP xml:id="I1.i1.omtext1.CMP2" about="#I1.i1.omtext1.CMP2" stex:srcref="/Users/Hang/lmh/localmh/MathHub/MiKoMH/GenCS/source/encryption/en/public-key-encryption.tex#textrange(from=11;19,to=12;68)">
<p id="I1.i1.omtext1.CMP2.p1" class="ltx_p" about="#I1.i1.omtext1.CMP2.p1" stex:srcref="/Users/Hang/lmh/localmh/MathHub/MiKoMH/GenCS/source/encryption/en/public-key-encryption.tex#textrange(from=11;19,to=12;68)">
<span class="ltx_text inlinedef">A
   <omdoc:term cd="public-key-encryption" name="digital-signature" role="definiendum" xml:id="I1.i1.omtext1.CMP2.p1.term1" about="#I1.i1.omtext1.CMP2.p1.term1" stex:srcref="Anonymous String#textrange(from=0;1,to=0;0)">digital signature
   </omdoc:term> consists of a plaintext together with
its ciphertext &#x2013; encoded with the sender&#x2019;s private key
</span>. A message signed
with a sender&#x2019;s private key can be verified by anyone who has access to the
sender&#x2019;s public key, thereby proving that the sender had access to the private
key (and therefore is likely to be the person associated with the public key
used), and the part of the message that has not been tampered with.
</p><img src="" id="I1.i1.omtext1.CMP2.g1" class="ltx_graphics ltx_centering" alt=""/>
</omdoc:CMP>
</omdoc:omtext>
```
