### PR TITLE
Model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: perl
 
 before_install:
  - sudo apt-get update -qq 
- - sudo apt-get install -qq libdb-dev libxml2-dev libxslt1-dev texlive-latex-base trang
+ - sudo apt-get install -qq libdb-dev libxml2-dev libxslt1-dev texlive-latex-base trang bash
 
 install:
  - cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 language: perl
 
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq libdb-dev libxml2-dev libxslt1-dev texlive-latex-base
+ - sudo apt-get update -qq 
+ - sudo apt-get install -qq libdb-dev libxml2-dev libxslt1-dev texlive-latex-base trang
 
 install:
  - cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,12 @@ use strict;
 use warnings;
 
 #======================================================================
+# Update omdoc+ltxml.model
+#======================================================================
+my $ifTrang = `command -v trang` or die "Trang is required but not installed";
+my $updateModel = `cd lib/LaTeXML/resources/RelaxNG/; make; make distclean`;
+
+#======================================================================
 # Use "perl Makefile.PL <options>"
 #======================================================================
 WriteMakefile(

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ use warnings;
 #======================================================================
 # Update omdoc+ltxml.model
 #======================================================================
-my $ifTrang = `command -v trang` or die "Trang is required but not installed";
+my $ifTrang = `type trang` or die "Trang is required but not installed";
 my $updateModel = `cd lib/LaTeXML/resources/RelaxNG/; make; make distclean`;
 
 #======================================================================

--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 # LaTeXML-Plugin-sTeX
 
 This is a [LaTeXML](http://dlmf.nist.gov/LaTeXML/) plugin for
-[sTeX](http://github.com/KWARC/sTeX). You will only be able to use this plugin after you
+[sTeX](http://github.com/KWARC/sTeX).
+
+### Prerequisites
+#### LaTeXML
+ You will only be able to use this plugin after you
 have LaTeXML installed, whose installation steps can be found
 [here](http://dlmf.nist.gov/LaTeXML/get.html).
+
+#### Trang
+This plug will also need
+[Trang](http://www.thaiopensource.com/relaxng/trang.html) for
+transforming the schema. 
+##### MAC OS 
+```
+brew install trang
+```
+##### Linux
+```
+sudo apt-get install trang
+```
+##### Windows 
+You can build trang from [Github](https://github.com/relaxng/jing-trang).
 
 ### How to install 
 Currently you can do the installation via `cpanm` or manually. Even though the two methods

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ have LaTeXML installed, whose installation steps can be found
 [here](http://dlmf.nist.gov/LaTeXML/get.html).
 
 #### Trang
-This plug will also need
+This plug in will also need
 [Trang](http://www.thaiopensource.com/relaxng/trang.html) for
 transforming the schema. 
 ##### MAC OS 


### PR DESCRIPTION
From this discussion http://stackoverflow.com/questions/23252042/how-to-handle-external-dependencies-in-perls-extutilsmakemaker, there seems to be no conventional way of handling third party dependency.

The point of using MakeMaker, which incorporates`Makefile.PL` to generate the actual Makefile is that the we don't have to worry about the build for other people on other platforms. MakeMaker essentially does the configurations work for different OS by us supplying some options.

To do what we want, which doesn't really have anything to do with `Makefile.PL`, we can simply list `trang` as a prerequisite and run the make in the schema directory just like in a normal perl script. 

P.S. `Makefile.PL` is also a normal perl script but it is just it imports `ExtUtils::MakeMaker` for installation purpose. 