### PR TITLE
Model integration 

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,11 +5,18 @@
 use ExtUtils::MakeMaker;
 use strict;
 use warnings;
+require Term::ANSIColor;
+use Term::ANSIColor;
 
 #======================================================================
 # Update omdoc+ltxml.model
 #======================================================================
-my $ifTrang = `type trang` or die "Trang is required but not installed";
+my $ifTrang = `type trang`;
+print color 'red';
+print "\nTrang is not found which could lead to a make failure.
+You can ignore this message if you do not intend to change the schema.
+See README for more info!\n\n" unless $ifTrang;
+print color 'reset';
 my $updateModel = `cd lib/LaTeXML/resources/RelaxNG/; make; make distclean`;
 
 #======================================================================


### PR DESCRIPTION
Follow up for #85 . Sorry for the confusion.

Due to the previous setup, the old integration would paralyze the `travis` test. The travis test doesn't like to execute shell command during build process. So I removed the make integration for updating the model in the other pull request. 

Given `trang` is not found, the current approach silences the error if the plugin is being installed via `cpanm`, and throws a non-blocking error when it is being installed manually, which is actually better, because `trang` is not a must have requirement for running the plugin, and thus not having it shouldn't block the whole installation process. 

This is how it looks like during the installation without `trang`
```shell
Hangs-MBP:LaTeXML-Plugin-sTeX Hang$ perl Makefile.PL 
/usr/bin/type: line 4: type: trang: not found

Trang is not found which could lead to a make failure.
You can ignore this message if you do not intend to change the schema.
See README for more info!

make: trang: No such file or directory
make: *** [LaTeXML.rng] Error 1
Generating a Unix-style Makefile
Writing Makefile for LaTeXML::Plugin::sTeX
Writing MYMETA.yml and MYMETA.json
Hangs-MBP:LaTeXML-Plugin-sTeX Hang$ cpanm . -n
--> Working on .
Configuring /Users/Hang/kwarc/LaTeXML-Plugin-sTeX ... OK
Building LaTeXML-Plugin-sTeX-0.2 ... OK
Successfully installed LaTeXML-Plugin-sTeX-0.2
1 distribution installed
```