### PR TITLE
Fix definiendum

### DIFF
--- a/lib/LaTeXML/Package/statements.sty.ltxml
+++ b/lib/LaTeXML/Package/statements.sty.ltxml
@@ -216,11 +216,9 @@ DefStatement('{notation} OptionalKeyVals:omtext',
 DefConstructor('\notatiendum OptionalKeyVals:notation {}',
               "<ltx:text class='notatiendum'>#2</ltx:text>");
 
-DefConstructor('\definiendum [] {}',
+DefConstructor('\definiendum OptionalKeyVals:DEF {}',
        "<omdoc:definiendum name='#name' cd='#theory'>"
-     .   "?&GetKeyVal(#1,'lemma')"
-     .              "(<omdoc:meta property='smglom:lemma'>&GetKeyVal(#1,'lemma')</omdoc:meta>)"
-     .              "()/>"
+     .   "?&GetKeyVal(#1,'lemma')(<omdoc:meta property='smglom:lemma'>&GetKeyVal(#1,'lemma')</omdoc:meta>)()/>"
      .   "#2"
      . "</omdoc:definiendum>",
        afterDigest => sub { defHelper(@_, 'definiendum'); });


### PR DESCRIPTION
Patch for #99 when given 
```tex
\begin{mhmodnl}[creators=jusche]{cakenumber}{de}
\begin{definition}
\definiendum[name=cakenumber,lemma=Koeffizient]{cakenumber} aus $R$ konstruiert
\end{definition}
\end{mhmodnl}
```

we have 
```xml
 <omdoc:definition for="cakenumber?name=cakenumber, lemma=Koeffizient" xml:id="cakenumber.de.definition4" about="#cakenumber.de.definition4" stex:srcref="smglom/numbers/source/cakenumber.de.tex#textrange(from=2;1,to=4;16)">
            <omdoc:CMP xml:id="cakenumber.de.definition4.CMP1" about="#cakenumber.de.definition4.CMP1" stex:srcref="smglom/numbers/source/cakenumber.de.tex#textrange(from=2;20,to=3;59)" xml:lang="de">
                <p xmlns="http://www.w3.org/1999/xhtml" id="cakenumber.de.definition4.CMP1.p1" class="ltx_p" about="#cakenumber.de.definition4.CMP1.p1" stex:srcref="smglom/numbers/source/cakenumber.de.tex#textrange(from=2;20,to=3;59)">
                    <omdoc:definiendum cd="cakenumber" name="name=cakenumber, lemma=Koeffizient">
                        <omdoc:meta property="smglom:lemma" xml:id="cakenumber.de.definition4.CMP1.p1.meta1" about="#cakenumber.de.definition4.CMP1.p1.meta1" stex:srcref="smglom/numbers/source/cakenumber.de.tex#textrange(from=2;20,to=3;59)">Coefficient
                        </omdoc:meta>/&gt;cakenumber
                    </omdoc:definiendum> aus
                    <om:OMOBJ stex:srcref="smglom/numbers/source/cakenumber.de.tex#textrange(from=2;13,to=3;67)">
                        <om:OMV name="&#x1D445;" /></om:OMOBJ> konstruiert</p>
            </omdoc:CMP>
        </omdoc:definition>
```