### PR TITLE
Fix trang detection.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,12 +11,9 @@ use Term::ANSIColor;
 #======================================================================
 # Update omdoc+ltxml.model
 #======================================================================
-my $ifTrang = `type trang`;
-print color 'red';
-print "\nTrang is not found which could lead to a make failure.
-You can ignore this message if you do not intend to change the schema.
-See README for more info!\n\n" unless $ifTrang;
-print color 'reset';
+# \033[0m makes the output red and \033[0m resets the output color
+my @args = ("bash", "-c", "type trang ||echo '\n\033[0;31mTrang is not found which could lead to a make failure.\nYou can ignore this message if you do not intend to change the schema.\nSee README for more info!\n \033[0m' ");
+my $ifTrang = system(@args);
 my $updateModel = `cd lib/LaTeXML/resources/RelaxNG/; make; make distclean`;
 
 #======================================================================


### PR DESCRIPTION
It turns out by default Perl invoke sh instead of the `bin/bash` that we want. 

This fixes the detection problem on Linux and works on Mac as well.

For ticket #102 .