### PR TITLE
Replaced missing LaTeXML::Core::Definition::Expandable::substituteTokens by substituteParameters.

### DIFF
--- a/lib/LaTeXML/Package/modules.sty.ltxml
+++ b/lib/LaTeXML/Package/modules.sty.ltxml
@@ -674,7 +674,7 @@ sub symdef_assemble_presentation {
   # When @args is undefined, we are creating a generic <omdoc:rendering>
   if ($nargs) {
     @args = map(Invocation(T_CS('\@SYMBOL'),T_OTHER("arg:".($_))),1..$nargs) unless scalar(@args);
-    $presentation = Tokens(LaTeXML::Core::Definition::Expandable::substituteTokens($presentation,@args));
+    $presentation = Tokens($presentation->substituteParameters(@args));
   }
   #Tokens(Invocation(T_CS('\@ensuremath'),$presentation)->unlist); 
   $presentation;}

--- a/lib/LaTeXML/Package/modules.sty.ltxml
+++ b/lib/LaTeXML/Package/modules.sty.ltxml
@@ -674,7 +674,7 @@ sub symdef_assemble_presentation {
   # When @args is undefined, we are creating a generic <omdoc:rendering>
   if ($nargs) {
     @args = map(Invocation(T_CS('\@SYMBOL'),T_OTHER("arg:".($_))),1..$nargs) unless scalar(@args);
-    $presentation = Tokens($presentation->substituteParameters(@args));
+    $presentation = $presentation->substituteParameters(@args);
   }
   #Tokens(Invocation(T_CS('\@ensuremath'),$presentation)->unlist); 
   $presentation;}


### PR DESCRIPTION
I am guessing that this is the right thing, at least it removes an error in my test document successfully:

```
\documentclass{omdoc}

\usepackage{modules}
\usepackage{cmath}

\begin{document}

\begin{module}[id=test]
  \symdef{test}[1]{\mathsf{Test}[#1]}

  $\test 1$
\end{module}

\end{document}
```