### PR TITLE
Fix: avoid casting Locator's to strings, use ->toAttribute instead.

### DIFF
--- a/lib/LaTeXML/Package/omtext.sty.ltxml
+++ b/lib/LaTeXML/Package/omtext.sty.ltxml
@@ -230,7 +230,9 @@ sub locateIt {
   my $locator = $node->getAttribute('stex:srcref');
   return unless $locator; # Nothing to do here...
   my $trailer = $whatsit && $whatsit->getProperty('trailer');
-  $trailer = $trailer->getLocator->toAttribute if $trailer;
+  if ($trailer) {
+    if (my $locator = $trailer->getLocator) {
+      $trailer = $locator->toAttribute; } }
   $trailer = $locator unless $trailer; # bootstrap
   # TODO: Both should be local, or both remote, any mixture or undefinedness will produce garbage
   my $file_path = LookupValue('SOURCEFILE');

--- a/lib/LaTeXML/Package/omtext.sty.ltxml
+++ b/lib/LaTeXML/Package/omtext.sty.ltxml
@@ -210,7 +210,7 @@ sub numberIt {
   my $about = $node -> getAttribute('about');
   $node->setAttribute('about'=>'#'.$node->getAttribute('xml:id')) unless $about;
   #Also, provide locators:
-  my $locator = $whatsit && $whatsit->getProperty('locator');
+  my $locator = $whatsit && $whatsit->getProperty('locator')->toAttribute;
   #Need to inherit locators if missing:
   $locator = (@parents ? $parents[$#parents]->getAttribute('stex:srcref') : '') unless $locator;
   if ($locator) {
@@ -230,7 +230,7 @@ sub locateIt {
   my $locator = $node->getAttribute('stex:srcref');
   return unless $locator; # Nothing to do here...
   my $trailer = $whatsit && $whatsit->getProperty('trailer');
-  $trailer = $trailer->getLocator if $trailer;
+  $trailer = $trailer->getLocator->toAttribute if $trailer;
   $trailer = $locator unless $trailer; # bootstrap
   # TODO: Both should be local, or both remote, any mixture or undefinedness will produce garbage
   my $file_path = LookupValue('SOURCEFILE');


### PR DESCRIPTION
(Directly casting to string gives garbled attributes like "LaTeXML::Common::Locator=HASH(...)")