### PR TITLE
re-pass test suite

### DIFF
--- a/lib/LaTeXML/Package/omtext.sty.ltxml
+++ b/lib/LaTeXML/Package/omtext.sty.ltxml
@@ -236,11 +236,21 @@ sub locateIt {
   my $locator = $node->getAttribute('stex:srcref');
   return unless $locator; # Nothing to do here...
   my $trailer = $whatsit && $whatsit->getProperty('trailer');
-
   if ($trailer) {
     if (my $locator = $trailer->getLocator) {
       $trailer = $locator->toAttribute; } }
-  # bootstrap if no explicit trailer
+  # No explicit trailer, can we use the locator of the last child box?
+  # ... not quite, as it is not precise enough, text nodes don't record their whatsits for instance
+  # so instead, focus on the srcref attribute
+  if (!$trailer) { 
+    my $last_node = $node->lastChild;
+    my $last_locator = (ref $last_node eq 'XML::LibXML::Element') && $last_node->getAttribute('stex:srcref');
+    while ($last_node && !$last_locator) {
+      $last_node = $last_node->previousNonBlankSibling; 
+      $last_locator = (ref $last_node eq 'XML::LibXML::Element') && $last_node->getAttribute('stex:srcref'); }
+    if ($last_locator) {
+      $trailer = $last_locator; } }
+  # if no trailer after all, just use the locator as a fallback, could be atomic
   if (!$trailer) {
     $trailer = $locator; }
   
@@ -250,17 +260,19 @@ sub locateIt {
   # Hmm, we only care about relative paths, so let's just do a URL->pathname map
   $file_path=~s/^\w+\:\/// if $file_path;
   $baselocal=~s/^\w+\:\/// if $baselocal;
+
   if ($file_path && $baselocal && ($locator =~ s/^([^\#]+)\#/\#/)) {
     my $relative_path = pathname_relative($file_path,$baselocal);
-    $locator = $relative_path.$locator;
-  }
+    $locator = $relative_path.$locator; }
+  
   if ($locator =~ /^(.+from=\d+;\d+)/) {
     my $from = $1;
     if ($trailer =~ /(,to=\d+;\d+.+)$/) {
       my $to = $1;
-      $locator = $from.$to;
-    } else { Error("stex","locator",undef, "Trailer is garbled, expect nonsense in stex:srcref ..."); }
-  } else { Error("stex","locator",undef, "Locator \"$locator\" is garbled, expect nonsense in stex:srcref ..."); }
+      $locator = $from.$to; }
+    else { Error("stex","locator",undef, "Trailer is garbled, expect nonsense in stex:srcref ..."); } }
+  else { Error("stex","locator",undef, "Locator \"$locator\" is garbled, expect nonsense in stex:srcref ..."); }
+
   my $parent = $document->getNode;
   if(! defined $parent->lookupNamespacePrefix("http://kwarc.info/ns/sTeX"))
     { # namespace not already declared?

--- a/lib/LaTeXML/Package/statements.sty.ltxml
+++ b/lib/LaTeXML/Package/statements.sty.ltxml
@@ -147,7 +147,7 @@ DefStatement('{typedec} OptionalKeyVals:omtext {}',
 # =======================================================
 sub definitionBody {
     my ($doc, $keyvals, %props) = @_;
-    my $for = $keyvals->getValue('for') if $keyvals;
+    my $for = $keyvals ? ToString($keyvals->getValue('for')) : '';
     my $type = $keyvals->getValue('type') if $keyvals;
     my %for_attr=();
     if ($props{theory}) {
@@ -162,7 +162,8 @@ sub definitionBody {
       }
     }
     my %attrs = ();
-    $for = join(" ",(sort keys %for_attr));
+    # use both the keyval for= information, as well as the theory-collected internals
+    $for .= join(" ",(sort keys %for_attr));
     $attrs{'for'} = $for if $for;
     my $id = $keyvals->getValue('id') if $keyvals;
     $attrs{'xml:id'} = $id if $id;
@@ -314,49 +315,47 @@ DefConstructor('\inlineass OptionalKeyVals:omtext {}',
 # 2.5 Symbols II:                                       #
 # =======================================================
 DefConstructor('\inlinedef OptionalKeyVals:omtext {}', sub {
- my ($document, $keyvals, $body, %props) = @_;
- my $for = $keyvals->getValue('for') if $keyvals;
- my %for_attr=();
- if (ToString($for)) {
-   $for = ToString($for);
-   $for =~ s/^{(.+)}$/$1/eg;
-   foreach (split(/,\s*/,$for)) {
-     $for_attr{$_}=1;
-   }}
- my @symbols = @{$props{defs} || []};
- #Prepare for symbol insertion -insert before the parent of the closest ancestor CMP element
- my $original_node = $document->getNode;
- my $statement_ancestor = $document->findnode('ancestor-or-self::omdoc:omtext[1] |
-					       ancestor-or-self::omdoc:assertion[1] | 
-					       ancestor-or-self::omdoc:axiom[1] |
-					       ancestor-or-self::omdoc:example[1]', $original_node);
- foreach my $symb(@symbols) {
-   next if $for_attr{$symb};
-   $for_attr{$symb}=1;
-   my $symbolnode = XML::LibXML::Element->new('symbol');
-   $symbolnode->setAttribute(name=>$symb);
-   $symbolnode->setAttribute("xml:id"=>makeNCName("$symb.def.sym"));
- if ($statement_ancestor) {
-   $statement_ancestor->parentNode->insertBefore($symbolnode,$statement_ancestor);
+  my ($document, $keyvals, $body, %props) = @_;
+  my %for_attr=();
+  my $for = $keyvals ? ToString($keyvals->getValue('for')) : '';
+  if ($for) {
+    $for =~ s/^{(.+)}$/$1/eg; # unwrap braces if given
+    foreach (split(/,?\s*/,$for)) { # support coma-delimited, as well as space-delimited
+      $for_attr{$_}=1; } }
+  my @symbols = @{$props{defs} || []};
+  #Prepare for symbol insertion -insert before the parent of the closest ancestor CMP element
+  my $original_node = $document->getNode;
+  my $statement_ancestor = $document->findnode('ancestor-or-self::omdoc:omtext[1] |
+                  ancestor-or-self::omdoc:assertion[1] | 
+                  ancestor-or-self::omdoc:axiom[1] |
+                  ancestor-or-self::omdoc:example[1]', $original_node);
+  foreach my $symb(@symbols) {
+    next if $for_attr{$symb};
+    $for_attr{$symb}=1;
+    my $symbolnode = XML::LibXML::Element->new('symbol');
+    $symbolnode->setAttribute(name=>$symb);
+    $symbolnode->setAttribute("xml:id"=>makeNCName("$symb.def.sym"));
+  if ($statement_ancestor) {
+    $statement_ancestor->parentNode->insertBefore($symbolnode,$statement_ancestor);
   } else {
     Error('malformed', $statement_ancestor, $original_node, "\\inlinedef outside a statement!
-Try wrapping the paragraph in a begin{omtext}, \\begin{assertion}, \\begin{axiom}...\nwhatever is suitable semantically.")}}
- #Restore the insertion point
- $document->setNode($original_node);
- my %attrs = ();
- $for = join(" ",(sort keys %for_attr));
- $attrs{'for'} = $for if $for;
- my $id = $keyvals->getValue('id') if $keyvals;
- $attrs{'xml:id'} = $id if $id;
- $attrs{'class'} = 'inlinedef';
- $document->openElement('ltx:text',%attrs);
- $document->absorb($body);
- $document->closeElement('ltx:text'); },
- #Prepare 'defs' hooks for \defi and \definiendum symbol names
+  Try wrapping the paragraph in a begin{omtext}, \\begin{assertion}, \\begin{axiom}...\nwhatever is suitable semantically.")}}
+  #Restore the insertion point
+  $document->setNode($original_node);
+  my %attrs = ();
+  $for = join(" ",(sort keys %for_attr));
+  $attrs{'for'} = $for if $for;
+  my $id = $keyvals->getValue('id') if $keyvals;
+  $attrs{'xml:id'} = $id if $id;
+  $attrs{'class'} = 'inlinedef';
+  $document->openElement('ltx:text',%attrs);
+  $document->absorb($body);
+  $document->closeElement('ltx:text'); },
+  #Prepare 'defs' hooks for \defi and \definiendum symbol names
   beforeDigest=>sub {
     AssignValue('defs', []);
     return; },
- #Adopt collected names as 'defs' property, remove hooks
+  #Adopt collected names as 'defs' property, remove hooks
   afterDigest=>sub {
     my ($stomach, $whatsit) = @_;
     my $defsref = LookupValue('defs') || [];
@@ -365,7 +364,7 @@ Try wrapping the paragraph in a begin{omtext}, \\begin{assertion}, \\begin{axiom
     my $local_defs = [ @$defsref ];
     $whatsit->setProperty('defs', $local_defs);
     AssignValue('defs',undef);
- return; });
+return; });
 
 # =======================================================
 # 3. Cross-Referencing Symbols and Concepts:            #

--- a/lib/LaTeXML/Package/statements.sty.ltxml
+++ b/lib/LaTeXML/Package/statements.sty.ltxml
@@ -71,7 +71,6 @@ sub hash_wrapper{
   return '' if (!@input);
   @input = sort map(split(/\s*,\s*/,$_),@input);
   my $output=join(".sym #",@input);
-  print STDERR "\n\nWTF: $output\n\n";
 
   $output=~s/(^\.sym )|[{}]//g; #remove leading space and list separator brackets
   "#$output"||'';

--- a/t/00_cds.t
+++ b/t/00_cds.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use XML::LibXML;
 
-use Test::More tests => 3;
+use Test::More tests => 33;
 
 my $eval_return = eval {
   use LaTeXML;
@@ -35,15 +35,15 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <theory about="#omdoc1.theory1" stex:srcref="Literal String \documentc#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1">
-    <metadata about="#omdoc1.theory1.metadata1" stex:srcref="Literal String \documentc#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1">
-      <dc:creator about="#omdoc1.theory1.metadata1.creator1" stex:srcref="Literal String \documentc#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.creator1"/>
-      <dc:contributor about="#omdoc1.theory1.metadata1.contributor2" stex:srcref="Literal String \documentc#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.contributor2"/>
-      <meta about="#omdoc1.theory1.metadata1.meta3" property="smglom:state" stex:srcref="Literal String \documentc#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.meta3"/>
+<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <theory about="#omdoc1.theory1" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1">
+    <metadata about="#omdoc1.theory1.metadata1" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1">
+      <dc:creator about="#omdoc1.theory1.metadata1.creator1" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.creator1"/>
+      <dc:contributor about="#omdoc1.theory1.metadata1.contributor2" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.contributor2"/>
+      <meta about="#omdoc1.theory1.metadata1.meta3" property="smglom:state" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.meta3"/>
     </metadata>
-    <symbol about="#omdoc1.theory1.symbol2" name="foo" stex:srcref="Literal String \documentc#textrange(from=4;0,to=4;24)" xml:id="omdoc1.theory1.symbol2"/>
-    <notation about="#omdoc1.theory1.notation3" cd="theory1" name="foo" stex:macro_name="foo" stex:nargs="0" stex:srcref="Literal String \documentc#textrange(from=4;0,to=4;24)" xml:id="omdoc1.theory1.notation3">
+    <symbol about="#omdoc1.theory1.symbol2" name="foo" stex:srcref="anonymous_string#textrange(from=4;0,to=4;24)" xml:id="omdoc1.theory1.symbol2"/>
+    <notation about="#omdoc1.theory1.notation3" cd="theory1" name="foo" stex:macro_name="foo" stex:nargs="0" stex:srcref="anonymous_string#textrange(from=4;0,to=4;24)" xml:id="omdoc1.theory1.notation3">
       <prototype>
         <om:OMS cd="theory1" name="foo"/>
       </prototype>
@@ -51,10 +51,10 @@ my $content_query = <<'EOQ';
         <text xmlns="http://dlmf.nist.gov/LaTeXML" class="ltx_markedasmath">foo</text>
       </rendering>
     </notation>
-    <symbol about="#foo.def.sym" name="foo" stex:srcref="Literal String \documentc#textrange(from=5;0,to=7;18)" xml:id="foo.def.sym"/>
-    <definition about="#foo.def" for="foo" stex:srcref="Literal String \documentc#textrange(from=5;0,to=7;18)" xml:id="foo.def">
-      <CMP about="#foo.def.CMP1" stex:srcref="Literal String \documentc#textrange(from=5;0,to=5;32)" xml:id="foo.def.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#foo.def.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=5;0,to=5;32)" xml:id="foo.def.CMP1.p1">A <definiendum cd="theory1" name="foo">foo</definiendum> (we write <Math about="#foo.def.CMP1.p1.m1" mode="inline" stex:srcref="Literal String \documentc#textrange(from=5;27,to=6;33)" tex="\@foo@construct[default]" text="foo" xml:id="foo.def.CMP1.p1.m1">
+    <symbol about="#foo.def.sym" name="foo" stex:srcref="anonymous_string#textrange(from=5;0,to=7;18)" xml:id="foo.def.sym"/>
+    <definition about="#foo.def" for="foo" stex:srcref="anonymous_string#textrange(from=5;0,to=7;18)" xml:id="foo.def">
+      <CMP about="#foo.def.CMP1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;5)" xml:id="foo.def.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#foo.def.CMP1.p1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;5)" xml:id="foo.def.CMP1.p1">A <definiendum cd="theory1" name="foo">foo</definiendum> (we write <Math about="#foo.def.CMP1.p1.m1" font="italic" mode="inline" stex:srcref="anonymous_string#textrange(from=5;27,to=6;33)" tex="\@foo@construct[default]" text="foo" xml:id="foo.def.CMP1.p1.m1">
             <XMath>
               <XMTok meaning="foo" name="foo" omcd="theory1"/>
             </XMath>
@@ -71,4 +71,14 @@ my $myResponse = $xml->parse_string($response->{result});
 $myResponse->removeChild(($myResponse->childNodes())[0]);
 
 is($response->{status_code},0,'Conversion was problem-free.');
-is($myResponse->toString(1),$content_query,'Content query successfully generated');
+
+my @got_lines = split("\n", $myResponse->toString(1));
+my @expected_lines = split("\n", $content_query);
+my $index = 0;
+while (@got_lines) {
+  $index++;
+  my $got_line = shift @got_lines;
+  my $expected_line = shift @expected_lines;
+  is($got_line, $expected_line,'Line $index was different than expected.');
+}
+

--- a/t/00_cds.t
+++ b/t/00_cds.t
@@ -53,8 +53,8 @@ my $content_query = <<'EOQ';
     </notation>
     <symbol about="#foo.def.sym" name="foo" stex:srcref="anonymous_string#textrange(from=5;0,to=7;18)" xml:id="foo.def.sym"/>
     <definition about="#foo.def" for="foo" stex:srcref="anonymous_string#textrange(from=5;0,to=7;18)" xml:id="foo.def">
-      <CMP about="#foo.def.CMP1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;5)" xml:id="foo.def.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#foo.def.CMP1.p1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;5)" xml:id="foo.def.CMP1.p1">A <definiendum cd="theory1" name="foo">foo</definiendum> (we write <Math about="#foo.def.CMP1.p1.m1" font="italic" mode="inline" stex:srcref="anonymous_string#textrange(from=5;27,to=6;33)" tex="\@foo@construct[default]" text="foo" xml:id="foo.def.CMP1.p1.m1">
+      <CMP about="#foo.def.CMP1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;33)" xml:id="foo.def.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#foo.def.CMP1.p1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;33)" xml:id="foo.def.CMP1.p1">A <definiendum cd="theory1" name="foo">foo</definiendum> (we write <Math about="#foo.def.CMP1.p1.m1" font="italic" mode="inline" stex:srcref="anonymous_string#textrange(from=5;27,to=6;33)" tex="\@foo@construct[default]" text="foo" xml:id="foo.def.CMP1.p1.m1">
             <XMath>
               <XMTok meaning="foo" name="foo" omcd="theory1"/>
             </XMath>
@@ -79,6 +79,6 @@ while (@got_lines) {
   $index++;
   my $got_line = shift @got_lines;
   my $expected_line = shift @expected_lines;
-  is($got_line, $expected_line,'Line $index was different than expected.');
+  is($got_line, $expected_line,"Compared line $index of XML output.");
 }
 

--- a/t/00_cds.t
+++ b/t/00_cds.t
@@ -31,7 +31,7 @@ EOQ
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT']);
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
-my $content_query = <<'EOQ';
+my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
@@ -73,7 +73,7 @@ $myResponse->removeChild(($myResponse->childNodes())[0]);
 is($response->{status_code},0,'Conversion was problem-free.');
 
 my @got_lines = split("\n", $myResponse->toString(1));
-my @expected_lines = split("\n", $content_query);
+my @expected_lines = split("\n", $target_xml);
 my $index = 0;
 while (@got_lines) {
   $index++;

--- a/t/01_cmath.t
+++ b/t/01_cmath.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use XML::LibXML;
 
-use Test::More tests => 3;
+use Test::More tests => 103;
 
 my $eval_return = eval {
   use LaTeXML;
@@ -33,7 +33,7 @@ EOQ
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT']);
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
-my $content_query = <<'EOQ';
+my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
@@ -41,13 +41,13 @@ my $content_query = <<'EOQ';
   <theory about="#mathapp" stex:srcref="anonymous_string#textrange(from=3;0,to=10;12)" xml:id="mathapp">
     <omtext about="#mathapp.omtext1" stex:srcref="anonymous_string#textrange(from=4;1,to=9;12)" xml:id="mathapp.omtext1">
       <CMP about="#mathapp.omtext1.CMP1" stex:srcref="anonymous_string#textrange(from=4;25,to=8;16)" xml:id="mathapp.omtext1.CMP1">
-        <equation xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="S0.Ex1">
+        <equation xmlns="http://dlmf.nist.gov/LaTeXML" font="italic" xml:id="S0.Ex1">
           <Math about="#S0.Ex1.m1" mode="display" stex:srcref="anonymous_string#textrange(from=4;25,to=8;16)" tex="\nappa{f}{a_{1},a_{2},a_{3}}\@napp@seq[]{f}{a_{1}}{a_{n}}\@napp@seq[]{f}{a_{1}%&#10;}{a_{n}}\@napp@seq[]{f}{a^{1}}{a^{n}}" text="f@(list@(a _ 1, a _ 2, a _ 3)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a ^ 1, sequencefromto, a ^ n))" xml:id="S0.Ex1.m1">
             <XMath>
               <XMApp>
                 <XMTok meaning="times" role="MULOP">⁢</XMTok>
                 <XMApp>
-                  <XMTok font="italic" role="UNKNOWN">f</XMTok>
+                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
                   <XMDual>
                     <XMApp>
                       <XMTok meaning="list"/>
@@ -58,72 +58,72 @@ my $content_query = <<'EOQ';
                     <XMWrap>
                       <XMApp xml:id="S0.Ex1.m1.1">
                         <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                        <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                        <XMTok meaning="1" role="NUMBER">1</XMTok>
+                        <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                        <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</XMTok>
                       </XMApp>
-                      <XMTok role="PUNCT">,</XMTok>
+                      <XMTok font="upright" mode="math" role="PUNCT">,</XMTok>
                       <XMApp xml:id="S0.Ex1.m1.2">
                         <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                        <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                        <XMTok meaning="2" role="NUMBER">2</XMTok>
+                        <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                        <XMTok font="upright" fontsize="70%" meaning="2" mode="math" role="NUMBER" rule="Subscript">2</XMTok>
                       </XMApp>
-                      <XMTok role="PUNCT">,</XMTok>
+                      <XMTok font="upright" mode="math" role="PUNCT">,</XMTok>
                       <XMApp xml:id="S0.Ex1.m1.3">
                         <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                        <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                        <XMTok meaning="3" role="NUMBER">3</XMTok>
+                        <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                        <XMTok font="upright" fontsize="70%" meaning="3" mode="math" role="NUMBER" rule="Subscript">3</XMTok>
                       </XMApp>
                     </XMWrap>
                   </XMDual>
                 </XMApp>
                 <XMApp>
-                  <XMTok font="italic" role="UNKNOWN">f</XMTok>
+                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
                   <XMApp>
                     <XMTok meaning="sequence"/>
                     <XMApp>
                       <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                      <XMTok meaning="1" role="NUMBER">1</XMTok>
+                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                      <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</XMTok>
                     </XMApp>
                     <XMTok meaning="sequencefromto"/>
                     <XMApp>
                       <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                      <XMTok font="italic" role="UNKNOWN">n</XMTok>
+                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                      <XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Subscript">n</XMTok>
                     </XMApp>
                   </XMApp>
                 </XMApp>
                 <XMApp>
-                  <XMTok font="italic" role="UNKNOWN">f</XMTok>
+                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
                   <XMApp>
                     <XMTok meaning="sequence"/>
                     <XMApp>
                       <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                      <XMTok meaning="1" role="NUMBER">1</XMTok>
+                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                      <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</XMTok>
                     </XMApp>
                     <XMTok meaning="sequencefromto"/>
                     <XMApp>
                       <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                      <XMTok font="italic" role="UNKNOWN">n</XMTok>
+                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                      <XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Subscript">n</XMTok>
                     </XMApp>
                   </XMApp>
                 </XMApp>
                 <XMApp>
-                  <XMTok font="italic" role="UNKNOWN">f</XMTok>
+                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
                   <XMApp>
                     <XMTok meaning="sequence"/>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post4"/>
-                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                      <XMTok meaning="1" role="NUMBER">1</XMTok>
+                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                      <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Superscript">1</XMTok>
                     </XMApp>
                     <XMTok meaning="sequencefromto"/>
                     <XMApp>
                       <XMTok role="SUPERSCRIPTOP" scriptpos="post4"/>
-                      <XMTok font="italic" role="UNKNOWN">a</XMTok>
-                      <XMTok font="italic" role="UNKNOWN">n</XMTok>
+                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
+                      <XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Superscript">n</XMTok>
                     </XMApp>
                   </XMApp>
                 </XMApp>
@@ -145,4 +145,12 @@ my $myResponse = $xml->parse_string($response->{result});
 $myResponse->removeChild(($myResponse->childNodes())[0]);
 
 is($response->{status_code},0,'Conversion was problem-free.');
-is($myResponse->toString(1),$content_query,'Content query successfully generated');
+my @got_lines = split("\n", $myResponse->toString(1));
+my @expected_lines = split("\n", $target_xml);
+my $index = 0;
+while (@got_lines) {
+  $index++;
+  my $got_line = shift @got_lines;
+  my $expected_line = shift @expected_lines;
+  is($got_line, $expected_line,"Compared line $index of XML output.");
+}

--- a/t/01_cmath.t
+++ b/t/01_cmath.t
@@ -37,12 +37,12 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <theory about="#mathapp" stex:srcref="Literal String \documentc#textrange(from=3;0,to=10;12)" xml:id="mathapp">
-    <omtext about="#mathapp.omtext1" stex:srcref="Literal String \documentc#textrange(from=4;1,to=9;12)" xml:id="mathapp.omtext1">
-      <CMP about="#mathapp.omtext1.CMP1" stex:srcref="Literal String \documentc#textrange(from=4;25,to=8;16)" xml:id="mathapp.omtext1.CMP1">
+<omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <theory about="#mathapp" stex:srcref="anonymous_string#textrange(from=3;0,to=10;12)" xml:id="mathapp">
+    <omtext about="#mathapp.omtext1" stex:srcref="anonymous_string#textrange(from=4;1,to=9;12)" xml:id="mathapp.omtext1">
+      <CMP about="#mathapp.omtext1.CMP1" stex:srcref="anonymous_string#textrange(from=4;25,to=8;16)" xml:id="mathapp.omtext1.CMP1">
         <equation xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="S0.Ex1">
-          <Math about="#S0.Ex1.m1" mode="display" stex:srcref="Literal String \documentc#textrange(from=4;25,to=8;16)" tex="\nappa{f}{a_{1},a_{2},a_{3}}\@napp@seq[]{f}{a_{1}}{a_{n}}\@napp@seq[]{f}{a_{1}%&#10;}{a_{n}}\@napp@seq[]{f}{a^{1}}{a^{n}}" text="f@(list@(a _ 1, a _ 2, a _ 3)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a ^ 1, sequencefromto, a ^ n))" xml:id="S0.Ex1.m1">
+          <Math about="#S0.Ex1.m1" mode="display" stex:srcref="anonymous_string#textrange(from=4;25,to=8;16)" tex="\nappa{f}{a_{1},a_{2},a_{3}}\@napp@seq[]{f}{a_{1}}{a_{n}}\@napp@seq[]{f}{a_{1}%&#10;}{a_{n}}\@napp@seq[]{f}{a^{1}}{a^{n}}" text="f@(list@(a _ 1, a _ 2, a _ 3)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a ^ 1, sequencefromto, a ^ n))" xml:id="S0.Ex1.m1">
             <XMath>
               <XMApp>
                 <XMTok meaning="times" role="MULOP">⁢</XMTok>

--- a/t/02_mikoslides.t
+++ b/t/02_mikoslides.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use XML::LibXML;
 
-use Test::More tests => 3;
+use Test::More tests => 30;
 
 my $eval_return = eval {
   use LaTeXML;
@@ -39,20 +39,20 @@ EOQ
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT']);
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
-my $content_query = <<'EOQ';
+my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
-<?latexml class="mikoslides" options="slides,showmeta,mh"?>
+<?latexml class="mikoslides" options="slides, showmeta, mh"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
 <omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
   <para xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="omdoc1.p1">
-    <p about="#omdoc1.p1.p1" xml:id="omdoc1.p1.p1">that is this…</p>
+    <p about="#omdoc1.p1.p1" stex:srcref="anonymous_string#textrange(from=3;14,to=4;5)" xml:id="omdoc1.p1.p1">that is this…</p>
   </para>
   <omgroup about="#omdoc1.omgroup2" layout="slide" stex:srcref="anonymous_string#textrange(from=7;13,to=10;11)" xml:id="omdoc1.omgroup2">
     <metadata about="#omdoc1.omgroup2.metadata1" stex:srcref="anonymous_string#textrange(from=8;0,to=8;26)" xml:id="omdoc1.omgroup2.metadata1">
       <dc:title about="#omdoc1.omgroup2.metadata1.title1" stex:srcref="anonymous_string#textrange(from=8;0,to=8;26)" xml:id="omdoc1.omgroup2.metadata1.title1">asdfadslfjk</dc:title>
     </metadata>
     <para xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="omdoc1.omgroup2.p1">
-      <p about="#omdoc1.omgroup2.p1.p1" xml:id="omdoc1.omgroup2.p1.p1">this is a frame….</p>
+      <p about="#omdoc1.omgroup2.p1.p1" stex:srcref="anonymous_string#textrange(from=8;18,to=9;7)" xml:id="omdoc1.omgroup2.p1.p1">this is a frame….</p>
     </para>
   </omgroup>
   <theory about="#omdoc1.theory3" stex:srcref="anonymous_string#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3">
@@ -63,7 +63,7 @@ my $content_query = <<'EOQ';
     </metadata>
     <omgroup about="#omdoc1.theory3.omgroup2" layout="slide" stex:srcref="anonymous_string#textrange(from=13;10,to=15;14)" xml:id="omdoc1.theory3.omgroup2">
       <para xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="omdoc1.theory3.omgroup2.p1">
-        <p about="#omdoc1.theory3.omgroup2.p1.p1" xml:id="omdoc1.theory3.omgroup2.p1.p1">try again!!</p>
+        <p about="#omdoc1.theory3.omgroup2.p1.p1" stex:srcref="anonymous_string#textrange(from=13;10,to=14;5)" xml:id="omdoc1.theory3.omgroup2.p1.p1">try again!!</p>
       </para>
     </omgroup>
   </theory>
@@ -76,4 +76,12 @@ my $myResponse = $xml->parse_string($response->{result});
 $myResponse->removeChild(($myResponse->childNodes())[0]);
 
 is($response->{status_code},0,'Conversion was problem-free.');
-is($myResponse->toString(1),$content_query,'Content query successfully generated');
+my @got_lines = split("\n", $myResponse->toString(1));
+my @expected_lines = split("\n", $target_xml);
+my $index = 0;
+while (@got_lines) {
+  $index++;
+  my $got_line = shift @got_lines;
+  my $expected_line = shift @expected_lines;
+  is($got_line, $expected_line,"Compared line $index of XML output.");
+}

--- a/t/02_mikoslides.t
+++ b/t/02_mikoslides.t
@@ -43,25 +43,25 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="mikoslides" options="slides,showmeta,mh"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
   <para xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="omdoc1.p1">
     <p about="#omdoc1.p1.p1" xml:id="omdoc1.p1.p1">that is this…</p>
   </para>
-  <omgroup about="#omdoc1.omgroup2" layout="slide" stex:srcref="Literal String \documentc#textrange(from=7;13,to=10;11)" xml:id="omdoc1.omgroup2">
-    <metadata about="#omdoc1.omgroup2.metadata1" stex:srcref="Literal String \documentc#textrange(from=8;0,to=8;26)" xml:id="omdoc1.omgroup2.metadata1">
-      <dc:title about="#omdoc1.omgroup2.metadata1.title1" stex:srcref="Literal String \documentc#textrange(from=8;0,to=8;26)" xml:id="omdoc1.omgroup2.metadata1.title1">asdfadslfjk</dc:title>
+  <omgroup about="#omdoc1.omgroup2" layout="slide" stex:srcref="anonymous_string#textrange(from=7;13,to=10;11)" xml:id="omdoc1.omgroup2">
+    <metadata about="#omdoc1.omgroup2.metadata1" stex:srcref="anonymous_string#textrange(from=8;0,to=8;26)" xml:id="omdoc1.omgroup2.metadata1">
+      <dc:title about="#omdoc1.omgroup2.metadata1.title1" stex:srcref="anonymous_string#textrange(from=8;0,to=8;26)" xml:id="omdoc1.omgroup2.metadata1.title1">asdfadslfjk</dc:title>
     </metadata>
     <para xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="omdoc1.omgroup2.p1">
       <p about="#omdoc1.omgroup2.p1.p1" xml:id="omdoc1.omgroup2.p1.p1">this is a frame….</p>
     </para>
   </omgroup>
-  <theory about="#omdoc1.theory3" stex:srcref="Literal String \documentc#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3">
-    <metadata about="#omdoc1.theory3.metadata1" stex:srcref="Literal String \documentc#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1">
-      <dc:creator about="#omdoc1.theory3.metadata1.creator1" stex:srcref="Literal String \documentc#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1.creator1"/>
-      <dc:contributor about="#omdoc1.theory3.metadata1.contributor2" stex:srcref="Literal String \documentc#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1.contributor2"/>
-      <meta about="#omdoc1.theory3.metadata1.meta3" property="smglom:state" stex:srcref="Literal String \documentc#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1.meta3"/>
+  <theory about="#omdoc1.theory3" stex:srcref="anonymous_string#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3">
+    <metadata about="#omdoc1.theory3.metadata1" stex:srcref="anonymous_string#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1">
+      <dc:creator about="#omdoc1.theory3.metadata1.creator1" stex:srcref="anonymous_string#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1.creator1"/>
+      <dc:contributor about="#omdoc1.theory3.metadata1.contributor2" stex:srcref="anonymous_string#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1.contributor2"/>
+      <meta about="#omdoc1.theory3.metadata1.meta3" property="smglom:state" stex:srcref="anonymous_string#textrange(from=12;1,to=16;12)" xml:id="omdoc1.theory3.metadata1.meta3"/>
     </metadata>
-    <omgroup about="#omdoc1.theory3.omgroup2" layout="slide" stex:srcref="Literal String \documentc#textrange(from=13;10,to=15;14)" xml:id="omdoc1.theory3.omgroup2">
+    <omgroup about="#omdoc1.theory3.omgroup2" layout="slide" stex:srcref="anonymous_string#textrange(from=13;10,to=15;14)" xml:id="omdoc1.theory3.omgroup2">
       <para xmlns="http://dlmf.nist.gov/LaTeXML" xml:id="omdoc1.theory3.omgroup2.p1">
         <p about="#omdoc1.theory3.omgroup2.p1.p1" xml:id="omdoc1.theory3.omgroup2.p1.p1">try again!!</p>
       </para>

--- a/t/03_modules2.t
+++ b/t/03_modules2.t
@@ -41,13 +41,13 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <theory about="#foo" stex:srcref="Literal String \documentc#textrange(from=3;0,to=5;12)" xml:id="foo"/>
-  <theory about="#foo2" stex:srcref="Literal String \documentc#textrange(from=7;0,to=9;12)" xml:id="foo2">
-    <imports about="#foo2.imports1" from="#foo" stex:srcref="Literal String \documentc#textrange(from=8;0,to=8;18)" xml:id="foo2.imports1"/>
+<omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <theory about="#foo" stex:srcref="anonymous_string#textrange(from=3;0,to=5;12)" xml:id="foo"/>
+  <theory about="#foo2" stex:srcref="anonymous_string#textrange(from=7;0,to=9;12)" xml:id="foo2">
+    <imports about="#foo2.imports1" from="#foo" stex:srcref="anonymous_string#textrange(from=8;0,to=8;18)" xml:id="foo2.imports1"/>
   </theory>
-  <theory about="#foo3" stex:srcref="Literal String \documentc#textrange(from=11;0,to=14;12)" xml:id="foo3">
-    <imports about="#foo3.imports1" from="#foo2" stex:srcref="Literal String \documentc#textrange(from=12;0,to=12;19)" xml:id="foo3.imports1"/>
+  <theory about="#foo3" stex:srcref="anonymous_string#textrange(from=11;0,to=14;12)" xml:id="foo3">
+    <imports about="#foo3.imports1" from="#foo2" stex:srcref="anonymous_string#textrange(from=12;0,to=12;19)" xml:id="foo3.imports1"/>
   </theory>
 </omdoc>
 EOQ

--- a/t/04_omtext.t
+++ b/t/04_omtext.t
@@ -36,18 +36,18 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <omtext about="#omdoc1.omtext1" stex:srcref="Literal String \documentc#textrange(from=3;0,to=5;12)" type="abstract" xml:id="omdoc1.omtext1">
-    <metadata about="#omdoc1.omtext1.metadata1" stex:srcref="Literal String \documentc#textrange(from=3;0,to=5;12)" xml:id="omdoc1.omtext1.metadata1">
-      <dc:title about="#omdoc1.omtext1.metadata1.title1" stex:srcref="Literal String \documentc#textrange(from=3;0,to=5;12)" xml:id="omdoc1.omtext1.metadata1.title1">newTitle</dc:title>
+<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <omtext about="#omdoc1.omtext1" stex:srcref="anonymous_string#textrange(from=3;0,to=5;12)" type="abstract" xml:id="omdoc1.omtext1">
+    <metadata about="#omdoc1.omtext1.metadata1" stex:srcref="anonymous_string#textrange(from=3;0,to=5;12)" xml:id="omdoc1.omtext1.metadata1">
+      <dc:title about="#omdoc1.omtext1.metadata1.title1" stex:srcref="anonymous_string#textrange(from=3;0,to=5;12)" xml:id="omdoc1.omtext1.metadata1.title1">newTitle</dc:title>
     </metadata>
-    <CMP about="#omdoc1.omtext1.CMP2" stex:srcref="Literal String \documentc#textrange(from=3;0,to=3;45)" xml:id="omdoc1.omtext1.CMP2">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext1.CMP2.p1" stex:srcref="Literal String \documentc#textrange(from=3;0,to=3;45)" xml:id="omdoc1.omtext1.CMP2.p1">Ni hao me.</p>
+    <CMP about="#omdoc1.omtext1.CMP2" stex:srcref="anonymous_string#textrange(from=3;0,to=3;45)" xml:id="omdoc1.omtext1.CMP2">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext1.CMP2.p1" stex:srcref="anonymous_string#textrange(from=3;0,to=3;45)" xml:id="omdoc1.omtext1.CMP2.p1">Ni hao me.</p>
     </CMP>
   </omtext>
-  <omtext about="#omdoc1.omtext2" stex:srcref="Literal String \documentc#textrange(from=7;0,to=9;12)" type="introduction" xml:id="omdoc1.omtext2">
-    <CMP about="#omdoc1.omtext2.CMP1" stex:srcref="Literal String \documentc#textrange(from=8;0,to=8;45)" xml:id="omdoc1.omtext2.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext2.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=8;0,to=8;45)" xml:id="omdoc1.omtext2.CMP1.p1"><text class="nlex">If <text class="coref-target" stex:index="1">hello</text> owns <text class="coref-source" stex:index="2">he</text>.</text></p>
+  <omtext about="#omdoc1.omtext2" stex:srcref="anonymous_string#textrange(from=7;0,to=9;12)" type="introduction" xml:id="omdoc1.omtext2">
+    <CMP about="#omdoc1.omtext2.CMP1" stex:srcref="anonymous_string#textrange(from=8;0,to=8;45)" xml:id="omdoc1.omtext2.CMP1">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext2.CMP1.p1" stex:srcref="anonymous_string#textrange(from=8;0,to=8;45)" xml:id="omdoc1.omtext2.CMP1.p1"><text class="nlex">If <text class="coref-target" stex:index="1">hello</text> owns <text class="coref-source" stex:index="2">he</text>.</text></p>
     </CMP>
   </omtext>
 </omdoc>

--- a/t/04_omtext.t
+++ b/t/04_omtext.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use XML::LibXML;
 
-use Test::More tests => 3;
+use Test::More tests => 20;
 
 my $eval_return = eval {
   use LaTeXML;
@@ -32,7 +32,7 @@ EOQ
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT']);
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
-my $content_query = <<'EOQ';
+my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
@@ -41,8 +41,8 @@ my $content_query = <<'EOQ';
     <metadata about="#omdoc1.omtext1.metadata1" stex:srcref="anonymous_string#textrange(from=3;0,to=5;12)" xml:id="omdoc1.omtext1.metadata1">
       <dc:title about="#omdoc1.omtext1.metadata1.title1" stex:srcref="anonymous_string#textrange(from=3;0,to=5;12)" xml:id="omdoc1.omtext1.metadata1.title1">newTitle</dc:title>
     </metadata>
-    <CMP about="#omdoc1.omtext1.CMP2" stex:srcref="anonymous_string#textrange(from=3;0,to=3;45)" xml:id="omdoc1.omtext1.CMP2">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext1.CMP2.p1" stex:srcref="anonymous_string#textrange(from=3;0,to=3;45)" xml:id="omdoc1.omtext1.CMP2.p1">Ni hao me.</p>
+    <CMP about="#omdoc1.omtext1.CMP2" stex:srcref="anonymous_string#textrange(from=3;9,to=4;2)" xml:id="omdoc1.omtext1.CMP2">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext1.CMP2.p1" stex:srcref="anonymous_string#textrange(from=3;9,to=4;2)" xml:id="omdoc1.omtext1.CMP2.p1">Ni hao me.</p>
     </CMP>
   </omtext>
   <omtext about="#omdoc1.omtext2" stex:srcref="anonymous_string#textrange(from=7;0,to=9;12)" type="introduction" xml:id="omdoc1.omtext2">
@@ -59,4 +59,12 @@ my $myResponse = $xml->parse_string($response->{result});
 $myResponse->removeChild(($myResponse->childNodes())[0]);
 
 is($response->{status_code},0,'Conversion was problem-free.');
-is($myResponse->toString(1),$content_query,'Content query successfully generated');
+my @got_lines = split("\n", $myResponse->toString(1));
+my @expected_lines = split("\n", $target_xml);
+my $index = 0;
+while (@got_lines) {
+  $index++;
+  my $got_line = shift @got_lines;
+  my $expected_line = shift @expected_lines;
+  is($got_line, $expected_line,"Compared line $index of XML output.");
+}

--- a/t/05_statements.t
+++ b/t/05_statements.t
@@ -48,10 +48,10 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <assertion about="#hello" stex:srcref="Literal String \documentc#textrange(from=3;0,to=5;15)" type="lemma" xml:id="hello">
-    <CMP about="#hello.CMP1" stex:srcref="Literal String \documentc#textrange(from=3;15,to=4;19)" xml:id="hello.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#hello.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=3;15,to=4;19)" xml:id="hello.CMP1.p1"><Math about="#hello.CMP1.p1.m1" mode="inline" stex:srcref="Literal String \documentc#textrange(from=3;15,to=4;19)" tex="Waohwerasd_{x}" text="W * a * o * h * w * e * r * a * s * d _ x" xml:id="hello.CMP1.p1.m1">
+<omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <assertion about="#hello" stex:srcref="anonymous_string#textrange(from=3;0,to=5;15)" type="lemma" xml:id="hello">
+    <CMP about="#hello.CMP1" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" xml:id="hello.CMP1">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#hello.CMP1.p1" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" xml:id="hello.CMP1.p1"><Math about="#hello.CMP1.p1.m1" mode="inline" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" tex="Waohwerasd_{x}" text="W * a * o * h * w * e * r * a * s * d _ x" xml:id="hello.CMP1.p1.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
@@ -74,23 +74,23 @@ my $content_query = <<'EOQ';
         </Math></p>
     </CMP>
   </assertion>
-  <axiom about="#newAx" stex:srcref="Literal String \documentc#textrange(from=7;0,to=9;11)" xml:id="newAx">
-    <CMP about="#newAx.CMP1" stex:srcref="Literal String \documentc#textrange(from=7;0,to=7;23)" xml:id="newAx.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#newAx.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=7;0,to=7;23)" xml:id="newAx.CMP1.p1">Thiasdf is not wokraw.</p>
+  <axiom about="#newAx" stex:srcref="anonymous_string#textrange(from=7;0,to=9;11)" xml:id="newAx">
+    <CMP about="#newAx.CMP1" stex:srcref="anonymous_string#textrange(from=7;0,to=7;23)" xml:id="newAx.CMP1">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#newAx.CMP1.p1" stex:srcref="anonymous_string#textrange(from=7;0,to=7;23)" xml:id="newAx.CMP1.p1">Thiasdf is not wokraw.</p>
     </CMP>
   </axiom>
-  <omtext about="#test.one" stex:srcref="Literal String \documentc#textrange(from=11;0,to=15;16)" type="definition" xml:id="test.one">
-    <CMP about="#test.one.CMP1" stex:srcref="Literal String \documentc#textrange(from=11;0,to=15;16)" xml:id="test.one.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#test.one.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=11;7,to=12;16)" xml:id="test.one.CMP1.p1"><definiendum name="concept">concept</definiendum> is this
+  <omtext about="#test.one" stex:srcref="anonymous_string#textrange(from=11;0,to=15;16)" type="definition" xml:id="test.one">
+    <CMP about="#test.one.CMP1" stex:srcref="anonymous_string#textrange(from=11;0,to=15;16)" xml:id="test.one.CMP1">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#test.one.CMP1.p1" stex:srcref="anonymous_string#textrange(from=11;7,to=12;16)" xml:id="test.one.CMP1.p1"><definiendum name="concept">concept</definiendum> is this
 <definiendum name="new-concerpt">new concerpt</definiendum>
 <definiendum name="old-new-concerpt">old new concerpt</definiendum></p>
     </CMP>
   </omtext>
-  <omtext about="#omdoc1.omtext4" stex:srcref="Literal String \documentc#textrange(from=17;1,to=21;16)" type="definition" xml:id="omdoc1.omtext4">
-    <CMP about="#omdoc1.omtext4.CMP1" stex:srcref="Literal String \documentc#textrange(from=17;1,to=21;16)" xml:id="omdoc1.omtext4.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext4.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=18;0,to=18;16)" xml:id="omdoc1.omtext4.CMP1.p1"><term about="#omdoc1.omtext4.CMP1.p1.term1" name="concept" stex:srcref="Literal String \documentc#textrange(from=18;0,to=18;16)" xml:id="omdoc1.omtext4.CMP1.p1.term1">concept</term>
-<term about="#omdoc1.omtext4.CMP1.p1.term2" name="new-concerpt" stex:srcref="Literal String \documentc#textrange(from=19;0,to=19;23)" xml:id="omdoc1.omtext4.CMP1.p1.term2">new concerpt</term>
-<term about="#omdoc1.omtext4.CMP1.p1.term3" name="old-new-concerpt" stex:srcref="Literal String \documentc#textrange(from=20;0,to=20;29)" xml:id="omdoc1.omtext4.CMP1.p1.term3">old new concerpt</term></p>
+  <omtext about="#omdoc1.omtext4" stex:srcref="anonymous_string#textrange(from=17;1,to=21;16)" type="definition" xml:id="omdoc1.omtext4">
+    <CMP about="#omdoc1.omtext4.CMP1" stex:srcref="anonymous_string#textrange(from=17;1,to=21;16)" xml:id="omdoc1.omtext4.CMP1">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext4.CMP1.p1" stex:srcref="anonymous_string#textrange(from=18;0,to=18;16)" xml:id="omdoc1.omtext4.CMP1.p1"><term about="#omdoc1.omtext4.CMP1.p1.term1" name="concept" stex:srcref="anonymous_string#textrange(from=18;0,to=18;16)" xml:id="omdoc1.omtext4.CMP1.p1.term1">concept</term>
+<term about="#omdoc1.omtext4.CMP1.p1.term2" name="new-concerpt" stex:srcref="anonymous_string#textrange(from=19;0,to=19;23)" xml:id="omdoc1.omtext4.CMP1.p1.term2">new concerpt</term>
+<term about="#omdoc1.omtext4.CMP1.p1.term3" name="old-new-concerpt" stex:srcref="anonymous_string#textrange(from=20;0,to=20;29)" xml:id="omdoc1.omtext4.CMP1.p1.term3">old new concerpt</term></p>
     </CMP>
   </omtext>
 </omdoc>

--- a/t/05_statements.t
+++ b/t/05_statements.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use XML::LibXML;
 
-use Test::More tests => 3;
+use Test::More tests => 51;
 
 my $eval_return = eval {
   use LaTeXML;
@@ -44,30 +44,30 @@ EOQ
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT'],profile=>'stex-smglom');
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
-my $content_query = <<'EOQ';
+my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
 <omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
   <assertion about="#hello" stex:srcref="anonymous_string#textrange(from=3;0,to=5;15)" type="lemma" xml:id="hello">
     <CMP about="#hello.CMP1" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" xml:id="hello.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#hello.CMP1.p1" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" xml:id="hello.CMP1.p1"><Math about="#hello.CMP1.p1.m1" mode="inline" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" tex="Waohwerasd_{x}" text="W * a * o * h * w * e * r * a * s * d _ x" xml:id="hello.CMP1.p1.m1">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#hello.CMP1.p1" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" xml:id="hello.CMP1.p1"><Math about="#hello.CMP1.p1.m1" font="italic" mode="inline" stex:srcref="anonymous_string#textrange(from=3;15,to=4;19)" tex="Waohwerasd_{x}" text="W * a * o * h * w * e * r * a * s * d _ x" xml:id="hello.CMP1.p1.m1">
           <XMath>
             <XMApp>
               <XMTok meaning="times" role="MULOP">⁢</XMTok>
-              <XMTok font="italic" role="UNKNOWN">W</XMTok>
-              <XMTok font="italic" role="UNKNOWN">a</XMTok>
-              <XMTok font="italic" role="UNKNOWN">o</XMTok>
-              <XMTok font="italic" role="UNKNOWN">h</XMTok>
-              <XMTok font="italic" role="UNKNOWN">w</XMTok>
-              <XMTok font="italic" role="UNKNOWN">e</XMTok>
-              <XMTok font="italic" role="UNKNOWN">r</XMTok>
-              <XMTok font="italic" role="UNKNOWN">a</XMTok>
-              <XMTok font="italic" role="UNKNOWN">s</XMTok>
+              <XMTok mode="math" role="UNKNOWN">W</XMTok>
+              <XMTok mode="math" role="UNKNOWN">a</XMTok>
+              <XMTok mode="math" role="UNKNOWN">o</XMTok>
+              <XMTok mode="math" role="UNKNOWN">h</XMTok>
+              <XMTok mode="math" role="UNKNOWN">w</XMTok>
+              <XMTok mode="math" role="UNKNOWN">e</XMTok>
+              <XMTok mode="math" role="UNKNOWN">r</XMTok>
+              <XMTok mode="math" role="UNKNOWN">a</XMTok>
+              <XMTok mode="math" role="UNKNOWN">s</XMTok>
               <XMApp>
                 <XMTok role="SUBSCRIPTOP" scriptpos="post3"/>
-                <XMTok font="italic" role="UNKNOWN">d</XMTok>
-                <XMTok font="italic" role="UNKNOWN">x</XMTok>
+                <XMTok mode="math" role="UNKNOWN">d</XMTok>
+                <XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Subscript">x</XMTok>
               </XMApp>
             </XMApp>
           </XMath>
@@ -75,8 +75,8 @@ my $content_query = <<'EOQ';
     </CMP>
   </assertion>
   <axiom about="#newAx" stex:srcref="anonymous_string#textrange(from=7;0,to=9;11)" xml:id="newAx">
-    <CMP about="#newAx.CMP1" stex:srcref="anonymous_string#textrange(from=7;0,to=7;23)" xml:id="newAx.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#newAx.CMP1.p1" stex:srcref="anonymous_string#textrange(from=7;0,to=7;23)" xml:id="newAx.CMP1.p1">Thiasdf is not wokraw.</p>
+    <CMP about="#newAx.CMP1" stex:srcref="anonymous_string#textrange(from=7;21,to=8;2)" xml:id="newAx.CMP1">
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#newAx.CMP1.p1" stex:srcref="anonymous_string#textrange(from=7;21,to=8;2)" xml:id="newAx.CMP1.p1">Thiasdf is not wokraw.</p>
     </CMP>
   </axiom>
   <omtext about="#test.one" stex:srcref="anonymous_string#textrange(from=11;0,to=15;16)" type="definition" xml:id="test.one">
@@ -88,7 +88,7 @@ my $content_query = <<'EOQ';
   </omtext>
   <omtext about="#omdoc1.omtext4" stex:srcref="anonymous_string#textrange(from=17;1,to=21;16)" type="definition" xml:id="omdoc1.omtext4">
     <CMP about="#omdoc1.omtext4.CMP1" stex:srcref="anonymous_string#textrange(from=17;1,to=21;16)" xml:id="omdoc1.omtext4.CMP1">
-      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext4.CMP1.p1" stex:srcref="anonymous_string#textrange(from=18;0,to=18;16)" xml:id="omdoc1.omtext4.CMP1.p1"><term about="#omdoc1.omtext4.CMP1.p1.term1" name="concept" stex:srcref="anonymous_string#textrange(from=18;0,to=18;16)" xml:id="omdoc1.omtext4.CMP1.p1.term1">concept</term>
+      <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.omtext4.CMP1.p1" stex:srcref="anonymous_string#textrange(from=18;0,to=20;29)" xml:id="omdoc1.omtext4.CMP1.p1"><term about="#omdoc1.omtext4.CMP1.p1.term1" name="concept" stex:srcref="anonymous_string#textrange(from=18;0,to=18;16)" xml:id="omdoc1.omtext4.CMP1.p1.term1">concept</term>
 <term about="#omdoc1.omtext4.CMP1.p1.term2" name="new-concerpt" stex:srcref="anonymous_string#textrange(from=19;0,to=19;23)" xml:id="omdoc1.omtext4.CMP1.p1.term2">new concerpt</term>
 <term about="#omdoc1.omtext4.CMP1.p1.term3" name="old-new-concerpt" stex:srcref="anonymous_string#textrange(from=20;0,to=20;29)" xml:id="omdoc1.omtext4.CMP1.p1.term3">old new concerpt</term></p>
     </CMP>
@@ -102,4 +102,12 @@ my $myResponse = $xml->parse_string($response->{result});
 $myResponse->removeChild(($myResponse->childNodes())[0]);
 
 is($response->{status_code},0,'Conversion was problem-free.');
-is($myResponse->toString(1),$content_query,'Content query successfully generated');
+my @got_lines = split("\n", $myResponse->toString(1));
+my @expected_lines = split("\n", $target_xml);
+my $index = 0;
+while (@got_lines) {
+  $index++;
+  my $got_line = shift @got_lines;
+  my $expected_line = shift @expected_lines;
+  is($got_line, $expected_line,"Compared line $index of XML output.");
+}

--- a/t/06_smglom.t
+++ b/t/06_smglom.t
@@ -33,10 +33,10 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <theory about="#foo" stex:srcref="Literal String \documentc#textrange(from=3;0,to=6;12)" xml:id="foo">
-    <symbol about="#foo.symbol1" name="foo" stex:srcref="Literal String \documentc#textrange(from=4;0,to=4;26)" xml:id="foo.symbol1"/>
-    <notation about="#foo.notation2" cd="foo" name="foo" stex:macro_name="foo" stex:nargs="0" stex:srcref="Literal String \documentc#textrange(from=4;0,to=4;26)" xml:id="foo.notation2">
+<omdoc xmlns="http://omdoc.org/ns" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <theory about="#foo" stex:srcref="anonymous_string#textrange(from=3;0,to=6;12)" xml:id="foo">
+    <symbol about="#foo.symbol1" name="foo" stex:srcref="anonymous_string#textrange(from=4;0,to=4;26)" xml:id="foo.symbol1"/>
+    <notation about="#foo.notation2" cd="foo" name="foo" stex:macro_name="foo" stex:nargs="0" stex:srcref="anonymous_string#textrange(from=4;0,to=4;26)" xml:id="foo.notation2">
       <prototype>
         <om:OMS cd="foo" name="foo"/>
       </prototype>

--- a/t/07_inlinedef.t
+++ b/t/07_inlinedef.t
@@ -5,7 +5,7 @@
 use strict;
 use warnings;
 use XML::LibXML;
-use Test::More tests => 3;
+use Test::More tests => 62;
 
 my $eval_return = eval {
   use LaTeXML;
@@ -25,31 +25,31 @@ my $tex_input = <<'EOQ';
   \end{omtext}
 
   \begin{omtext}
-    Here is some text \inlinedef{This is called \defi{this}}
+    Here is some text \inlinedef{This is called \defi{this2}}
   \end{omtext}
 
   \begin{assertion}
-   \inlinedef{This is called \defi{seasdcond}}
+   \inlinedef{This is called \defi{second}}
   \end{assertion}
 
   \begin{assertion}
-   Ni hall \inlinedef{This is called \defiii{second}{asdf}{gas}}
+   Ni hall \inlinedef{This is called \defiii{second}{word}{word2}}
   \end{assertion}
 
   \begin{axiom}
-   asdf  \inlinedef{This is called \defi{thistry}}
+   word  \inlinedef{This is called \defi{fourth}}
   \end{axiom}
 
   \begin{axiom}
-    \inlinedef{This is called \defi{thisfastry}{gasdg}}
+    \inlinedef{This is called \defi{fifth}{sixth}}
   \end{axiom}
 
   \begin{example}
-     \inlinedef{This is called \defi{ffss}}
+     \inlinedef{This is called \defi{seventh}}
   \end{example}
 
   \begin{example}
-     nothign \inlinedef{This is called \defii{asd}{fasd}}
+     nothing \inlinedef{This is called \defii{word3}{word4}}
   \end{example}
 \end{module}
 \end{document}
@@ -58,7 +58,8 @@ EOQ
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT']);
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
-my $content_query = <<'EOQ';
+print STDERR "\n", $$response{log},"\n";
+my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
@@ -72,48 +73,49 @@ my $content_query = <<'EOQ';
     <symbol name="this" xml:id="this.def.sym"/>
     <omtext about="#omdoc1.theory1.omtext2" stex:srcref="anonymous_string#textrange(from=5;1,to=7;14)" xml:id="omdoc1.theory1.omtext2">
       <CMP about="#omdoc1.theory1.omtext2.CMP1" stex:srcref="anonymous_string#textrange(from=6;0,to=6;42)" xml:id="omdoc1.theory1.omtext2.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext2.CMP1.p1" stex:srcref="anonymous_string#textrange(from=6;0,to=6;42)" xml:id="omdoc1.theory1.omtext2.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="this">this</definiendum></text></p>
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext2.CMP1.p1" stex:srcref="anonymous_string#textrange(from=6;0,to=6;42)" xml:id="omdoc1.theory1.omtext2.CMP1.p1"><text class="inlinedef" for="this">This is called <definiendum cd="theory1" name="this">this</definiendum></text></p>
       </CMP>
     </omtext>
+    <symbol name="this2" xml:id="this2.def.sym"/>
     <omtext about="#omdoc1.theory1.omtext4" stex:srcref="anonymous_string#textrange(from=9;1,to=11;14)" xml:id="omdoc1.theory1.omtext4">
-      <CMP about="#omdoc1.theory1.omtext4.CMP1" stex:srcref="anonymous_string#textrange(from=9;1,to=9;17)" xml:id="omdoc1.theory1.omtext4.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext4.CMP1.p1" stex:srcref="anonymous_string#textrange(from=9;1,to=9;17)" xml:id="omdoc1.theory1.omtext4.CMP1.p1">Here is some text <text class="inlinedef">This is called <definiendum cd="theory1" name="this">this</definiendum></text></p>
+      <CMP about="#omdoc1.theory1.omtext4.CMP1" stex:srcref="anonymous_string#textrange(from=9;56,to=10;5)" xml:id="omdoc1.theory1.omtext4.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext4.CMP1.p1" stex:srcref="anonymous_string#textrange(from=9;56,to=10;5)" xml:id="omdoc1.theory1.omtext4.CMP1.p1">Here is some text <text class="inlinedef" for="this2">This is called <definiendum cd="theory1" name="this2">this2</definiendum></text></p>
       </CMP>
     </omtext>
-    <symbol name="seasdcond" xml:id="seasdcond.def.sym"/>
-    <assertion about="#omdoc1.theory1.assertion5" stex:srcref="anonymous_string#textrange(from=13;1,to=15;17)" xml:id="omdoc1.theory1.assertion5">
-      <CMP about="#omdoc1.theory1.assertion5.CMP1" stex:srcref="anonymous_string#textrange(from=14;0,to=14;46)" xml:id="omdoc1.theory1.assertion5.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion5.CMP1.p1" stex:srcref="anonymous_string#textrange(from=14;0,to=14;46)" xml:id="omdoc1.theory1.assertion5.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="seasdcond">seasdcond</definiendum></text></p>
+    <symbol name="second" xml:id="second.def.sym"/>
+    <assertion about="#omdoc1.theory1.assertion6" stex:srcref="anonymous_string#textrange(from=13;1,to=15;17)" xml:id="omdoc1.theory1.assertion6">
+      <CMP about="#omdoc1.theory1.assertion6.CMP1" stex:srcref="anonymous_string#textrange(from=14;0,to=14;43)" xml:id="omdoc1.theory1.assertion6.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion6.CMP1.p1" stex:srcref="anonymous_string#textrange(from=14;0,to=14;43)" xml:id="omdoc1.theory1.assertion6.CMP1.p1"><text class="inlinedef" for="second">This is called <definiendum cd="theory1" name="second">second</definiendum></text></p>
       </CMP>
     </assertion>
-    <symbol name="second-asdf-gas" xml:id="second-asdf-gas.def.sym"/>
-    <assertion about="#omdoc1.theory1.assertion7" stex:srcref="anonymous_string#textrange(from=17;1,to=19;17)" xml:id="omdoc1.theory1.assertion7">
-      <CMP about="#omdoc1.theory1.assertion7.CMP1" stex:srcref="anonymous_string#textrange(from=17;1,to=17;20)" xml:id="omdoc1.theory1.assertion7.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion7.CMP1.p1" stex:srcref="anonymous_string#textrange(from=17;1,to=17;20)" xml:id="omdoc1.theory1.assertion7.CMP1.p1">Ni hall <text class="inlinedef">This is called <definiendum cd="theory1" name="second-asdf-gas">second asdf gas</definiendum></text></p>
+    <symbol name="second-word-word2" xml:id="second-word-word2.def.sym"/>
+    <assertion about="#omdoc1.theory1.assertion8" stex:srcref="anonymous_string#textrange(from=17;1,to=19;17)" xml:id="omdoc1.theory1.assertion8">
+      <CMP about="#omdoc1.theory1.assertion8.CMP1" stex:srcref="anonymous_string#textrange(from=17;62,to=18;4)" xml:id="omdoc1.theory1.assertion8.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion8.CMP1.p1" stex:srcref="anonymous_string#textrange(from=17;62,to=18;4)" xml:id="omdoc1.theory1.assertion8.CMP1.p1">Ni hall <text class="inlinedef" for="second-word-word2">This is called <definiendum cd="theory1" name="second-word-word2">second word word2</definiendum></text></p>
       </CMP>
     </assertion>
-    <symbol name="thistry" xml:id="thistry.def.sym"/>
-    <axiom about="#omdoc1.theory1.axiom9" stex:srcref="anonymous_string#textrange(from=21;1,to=23;13)" xml:id="omdoc1.theory1.axiom9">
-      <CMP about="#omdoc1.theory1.axiom9.CMP1" stex:srcref="anonymous_string#textrange(from=21;1,to=21;16)" xml:id="omdoc1.theory1.axiom9.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom9.CMP1.p1" stex:srcref="anonymous_string#textrange(from=21;1,to=21;16)" xml:id="omdoc1.theory1.axiom9.CMP1.p1">asdf <text class="inlinedef">This is called <definiendum cd="theory1" name="thistry">thistry</definiendum></text></p>
+    <symbol name="fourth" xml:id="fourth.def.sym"/>
+    <axiom about="#omdoc1.theory1.axiom10" stex:srcref="anonymous_string#textrange(from=21;1,to=23;13)" xml:id="omdoc1.theory1.axiom10">
+      <CMP about="#omdoc1.theory1.axiom10.CMP1" stex:srcref="anonymous_string#textrange(from=21;45,to=22;4)" xml:id="omdoc1.theory1.axiom10.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom10.CMP1.p1" stex:srcref="anonymous_string#textrange(from=21;45,to=22;4)" xml:id="omdoc1.theory1.axiom10.CMP1.p1">word <text class="inlinedef" for="fourth">This is called <definiendum cd="theory1" name="fourth">fourth</definiendum></text></p>
       </CMP>
     </axiom>
-<!--  %**** String Line 25 **** -->    <symbol name="thisfastry" xml:id="thisfastry.def.sym"/>
-    <axiom about="#omdoc1.theory1.axiom11" stex:srcref="anonymous_string#textrange(from=25;1,to=27;13)" xml:id="omdoc1.theory1.axiom11">
-      <CMP about="#omdoc1.theory1.axiom11.CMP1" stex:srcref="anonymous_string#textrange(from=26;0,to=26;55)" xml:id="omdoc1.theory1.axiom11.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom11.CMP1.p1" stex:srcref="anonymous_string#textrange(from=26;0,to=26;55)" xml:id="omdoc1.theory1.axiom11.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="thisfastry">thisfastry</definiendum>gasdg</text></p>
+<!--  %**** String Line 25 **** -->    <symbol name="fifth" xml:id="fifth.def.sym"/>
+    <axiom about="#omdoc1.theory1.axiom12" stex:srcref="anonymous_string#textrange(from=25;1,to=27;13)" xml:id="omdoc1.theory1.axiom12">
+      <CMP about="#omdoc1.theory1.axiom12.CMP1" stex:srcref="anonymous_string#textrange(from=26;0,to=26;50)" xml:id="omdoc1.theory1.axiom12.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom12.CMP1.p1" stex:srcref="anonymous_string#textrange(from=26;0,to=26;50)" xml:id="omdoc1.theory1.axiom12.CMP1.p1"><text class="inlinedef" for="fifth">This is called <definiendum cd="theory1" name="fifth">fifth</definiendum>sixth</text></p>
       </CMP>
     </axiom>
-    <symbol name="ffss" xml:id="ffss.def.sym"/>
-    <example about="#omdoc1.theory1.example13" stex:srcref="anonymous_string#textrange(from=29;1,to=31;15)" xml:id="omdoc1.theory1.example13">
-      <CMP about="#omdoc1.theory1.example13.CMP1" stex:srcref="anonymous_string#textrange(from=30;0,to=30;43)" xml:id="omdoc1.theory1.example13.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example13.CMP1.p1" stex:srcref="anonymous_string#textrange(from=30;0,to=30;43)" xml:id="omdoc1.theory1.example13.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="ffss">ffss</definiendum></text></p>
+    <symbol name="seventh" xml:id="seventh.def.sym"/>
+    <example about="#omdoc1.theory1.example14" stex:srcref="anonymous_string#textrange(from=29;1,to=31;15)" xml:id="omdoc1.theory1.example14">
+      <CMP about="#omdoc1.theory1.example14.CMP1" stex:srcref="anonymous_string#textrange(from=30;0,to=30;46)" xml:id="omdoc1.theory1.example14.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example14.CMP1.p1" stex:srcref="anonymous_string#textrange(from=30;0,to=30;46)" xml:id="omdoc1.theory1.example14.CMP1.p1"><text class="inlinedef" for="seventh">This is called <definiendum cd="theory1" name="seventh">seventh</definiendum></text></p>
       </CMP>
     </example>
-    <symbol name="asd-fasd" xml:id="asd-fasd.def.sym"/>
-    <example about="#omdoc1.theory1.example15" stex:srcref="anonymous_string#textrange(from=33;1,to=35;15)" xml:id="omdoc1.theory1.example15">
-      <CMP about="#omdoc1.theory1.example15.CMP1" stex:srcref="anonymous_string#textrange(from=33;1,to=33;18)" xml:id="omdoc1.theory1.example15.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example15.CMP1.p1" stex:srcref="anonymous_string#textrange(from=33;1,to=33;18)" xml:id="omdoc1.theory1.example15.CMP1.p1">nothign <text class="inlinedef">This is called <definiendum cd="theory1" name="asd-fasd">asd fasd</definiendum></text></p>
+    <symbol name="word3-word4" xml:id="word3-word4.def.sym"/>
+    <example about="#omdoc1.theory1.example16" stex:srcref="anonymous_string#textrange(from=33;1,to=35;15)" xml:id="omdoc1.theory1.example16">
+      <CMP about="#omdoc1.theory1.example16.CMP1" stex:srcref="anonymous_string#textrange(from=33;54,to=34;6)" xml:id="omdoc1.theory1.example16.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example16.CMP1.p1" stex:srcref="anonymous_string#textrange(from=33;54,to=34;6)" xml:id="omdoc1.theory1.example16.CMP1.p1">nothing <text class="inlinedef" for="word3-word4">This is called <definiendum cd="theory1" name="word3-word4">word3 word4</definiendum></text></p>
       </CMP>
     </example>
   </theory>
@@ -126,4 +128,12 @@ my $myResponse = $xml->parse_string($response->{result});
 $myResponse->removeChild(($myResponse->childNodes())[0]);
 
 is($response->{status_code},0,'Conversion was problem-free.');
-is($myResponse->toString(1),$content_query,'Content query successfully generated');
+my @got_lines = split("\n", $myResponse->toString(1));
+my @expected_lines = split("\n", $target_xml);
+my $index = 0;
+while (@got_lines) {
+  $index++;
+  my $got_line = shift @got_lines;
+  my $expected_line = shift @expected_lines;
+  is($got_line, $expected_line,"Compared line $index of XML output.");
+}

--- a/t/07_inlinedef.t
+++ b/t/07_inlinedef.t
@@ -62,58 +62,58 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="Literal String \documentc#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <theory about="#omdoc1.theory1" stex:srcref="Literal String \documentc#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1">
-    <metadata about="#omdoc1.theory1.metadata1" stex:srcref="Literal String \documentc#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1">
-      <dc:creator about="#omdoc1.theory1.metadata1.creator1" stex:srcref="Literal String \documentc#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1.creator1"/>
-      <dc:contributor about="#omdoc1.theory1.metadata1.contributor2" stex:srcref="Literal String \documentc#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1.contributor2"/>
-      <meta about="#omdoc1.theory1.metadata1.meta3" property="smglom:state" stex:srcref="Literal String \documentc#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1.meta3"/>
+<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <theory about="#omdoc1.theory1" stex:srcref="anonymous_string#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1">
+    <metadata about="#omdoc1.theory1.metadata1" stex:srcref="anonymous_string#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1">
+      <dc:creator about="#omdoc1.theory1.metadata1.creator1" stex:srcref="anonymous_string#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1.creator1"/>
+      <dc:contributor about="#omdoc1.theory1.metadata1.contributor2" stex:srcref="anonymous_string#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1.contributor2"/>
+      <meta about="#omdoc1.theory1.metadata1.meta3" property="smglom:state" stex:srcref="anonymous_string#textrange(from=3;1,to=36;12)" xml:id="omdoc1.theory1.metadata1.meta3"/>
     </metadata>
     <symbol name="this" xml:id="this.def.sym"/>
-    <omtext about="#omdoc1.theory1.omtext2" stex:srcref="Literal String \documentc#textrange(from=5;1,to=7;14)" xml:id="omdoc1.theory1.omtext2">
-      <CMP about="#omdoc1.theory1.omtext2.CMP1" stex:srcref="Literal String \documentc#textrange(from=6;0,to=6;42)" xml:id="omdoc1.theory1.omtext2.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext2.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=6;0,to=6;42)" xml:id="omdoc1.theory1.omtext2.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="this">this</definiendum></text></p>
+    <omtext about="#omdoc1.theory1.omtext2" stex:srcref="anonymous_string#textrange(from=5;1,to=7;14)" xml:id="omdoc1.theory1.omtext2">
+      <CMP about="#omdoc1.theory1.omtext2.CMP1" stex:srcref="anonymous_string#textrange(from=6;0,to=6;42)" xml:id="omdoc1.theory1.omtext2.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext2.CMP1.p1" stex:srcref="anonymous_string#textrange(from=6;0,to=6;42)" xml:id="omdoc1.theory1.omtext2.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="this">this</definiendum></text></p>
       </CMP>
     </omtext>
-    <omtext about="#omdoc1.theory1.omtext4" stex:srcref="Literal String \documentc#textrange(from=9;1,to=11;14)" xml:id="omdoc1.theory1.omtext4">
-      <CMP about="#omdoc1.theory1.omtext4.CMP1" stex:srcref="Literal String \documentc#textrange(from=9;1,to=9;17)" xml:id="omdoc1.theory1.omtext4.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext4.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=9;1,to=9;17)" xml:id="omdoc1.theory1.omtext4.CMP1.p1">Here is some text <text class="inlinedef">This is called <definiendum cd="theory1" name="this">this</definiendum></text></p>
+    <omtext about="#omdoc1.theory1.omtext4" stex:srcref="anonymous_string#textrange(from=9;1,to=11;14)" xml:id="omdoc1.theory1.omtext4">
+      <CMP about="#omdoc1.theory1.omtext4.CMP1" stex:srcref="anonymous_string#textrange(from=9;1,to=9;17)" xml:id="omdoc1.theory1.omtext4.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.omtext4.CMP1.p1" stex:srcref="anonymous_string#textrange(from=9;1,to=9;17)" xml:id="omdoc1.theory1.omtext4.CMP1.p1">Here is some text <text class="inlinedef">This is called <definiendum cd="theory1" name="this">this</definiendum></text></p>
       </CMP>
     </omtext>
     <symbol name="seasdcond" xml:id="seasdcond.def.sym"/>
-    <assertion about="#omdoc1.theory1.assertion5" stex:srcref="Literal String \documentc#textrange(from=13;1,to=15;17)" xml:id="omdoc1.theory1.assertion5">
-      <CMP about="#omdoc1.theory1.assertion5.CMP1" stex:srcref="Literal String \documentc#textrange(from=14;0,to=14;46)" xml:id="omdoc1.theory1.assertion5.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion5.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=14;0,to=14;46)" xml:id="omdoc1.theory1.assertion5.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="seasdcond">seasdcond</definiendum></text></p>
+    <assertion about="#omdoc1.theory1.assertion5" stex:srcref="anonymous_string#textrange(from=13;1,to=15;17)" xml:id="omdoc1.theory1.assertion5">
+      <CMP about="#omdoc1.theory1.assertion5.CMP1" stex:srcref="anonymous_string#textrange(from=14;0,to=14;46)" xml:id="omdoc1.theory1.assertion5.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion5.CMP1.p1" stex:srcref="anonymous_string#textrange(from=14;0,to=14;46)" xml:id="omdoc1.theory1.assertion5.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="seasdcond">seasdcond</definiendum></text></p>
       </CMP>
     </assertion>
     <symbol name="second-asdf-gas" xml:id="second-asdf-gas.def.sym"/>
-    <assertion about="#omdoc1.theory1.assertion7" stex:srcref="Literal String \documentc#textrange(from=17;1,to=19;17)" xml:id="omdoc1.theory1.assertion7">
-      <CMP about="#omdoc1.theory1.assertion7.CMP1" stex:srcref="Literal String \documentc#textrange(from=17;1,to=17;20)" xml:id="omdoc1.theory1.assertion7.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion7.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=17;1,to=17;20)" xml:id="omdoc1.theory1.assertion7.CMP1.p1">Ni hall <text class="inlinedef">This is called <definiendum cd="theory1" name="second-asdf-gas">second asdf gas</definiendum></text></p>
+    <assertion about="#omdoc1.theory1.assertion7" stex:srcref="anonymous_string#textrange(from=17;1,to=19;17)" xml:id="omdoc1.theory1.assertion7">
+      <CMP about="#omdoc1.theory1.assertion7.CMP1" stex:srcref="anonymous_string#textrange(from=17;1,to=17;20)" xml:id="omdoc1.theory1.assertion7.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.assertion7.CMP1.p1" stex:srcref="anonymous_string#textrange(from=17;1,to=17;20)" xml:id="omdoc1.theory1.assertion7.CMP1.p1">Ni hall <text class="inlinedef">This is called <definiendum cd="theory1" name="second-asdf-gas">second asdf gas</definiendum></text></p>
       </CMP>
     </assertion>
     <symbol name="thistry" xml:id="thistry.def.sym"/>
-    <axiom about="#omdoc1.theory1.axiom9" stex:srcref="Literal String \documentc#textrange(from=21;1,to=23;13)" xml:id="omdoc1.theory1.axiom9">
-      <CMP about="#omdoc1.theory1.axiom9.CMP1" stex:srcref="Literal String \documentc#textrange(from=21;1,to=21;16)" xml:id="omdoc1.theory1.axiom9.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom9.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=21;1,to=21;16)" xml:id="omdoc1.theory1.axiom9.CMP1.p1">asdf <text class="inlinedef">This is called <definiendum cd="theory1" name="thistry">thistry</definiendum></text></p>
+    <axiom about="#omdoc1.theory1.axiom9" stex:srcref="anonymous_string#textrange(from=21;1,to=23;13)" xml:id="omdoc1.theory1.axiom9">
+      <CMP about="#omdoc1.theory1.axiom9.CMP1" stex:srcref="anonymous_string#textrange(from=21;1,to=21;16)" xml:id="omdoc1.theory1.axiom9.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom9.CMP1.p1" stex:srcref="anonymous_string#textrange(from=21;1,to=21;16)" xml:id="omdoc1.theory1.axiom9.CMP1.p1">asdf <text class="inlinedef">This is called <definiendum cd="theory1" name="thistry">thistry</definiendum></text></p>
       </CMP>
     </axiom>
 <!--  %**** String Line 25 **** -->    <symbol name="thisfastry" xml:id="thisfastry.def.sym"/>
-    <axiom about="#omdoc1.theory1.axiom11" stex:srcref="Literal String \documentc#textrange(from=25;1,to=27;13)" xml:id="omdoc1.theory1.axiom11">
-      <CMP about="#omdoc1.theory1.axiom11.CMP1" stex:srcref="Literal String \documentc#textrange(from=26;0,to=26;55)" xml:id="omdoc1.theory1.axiom11.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom11.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=26;0,to=26;55)" xml:id="omdoc1.theory1.axiom11.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="thisfastry">thisfastry</definiendum>gasdg</text></p>
+    <axiom about="#omdoc1.theory1.axiom11" stex:srcref="anonymous_string#textrange(from=25;1,to=27;13)" xml:id="omdoc1.theory1.axiom11">
+      <CMP about="#omdoc1.theory1.axiom11.CMP1" stex:srcref="anonymous_string#textrange(from=26;0,to=26;55)" xml:id="omdoc1.theory1.axiom11.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.axiom11.CMP1.p1" stex:srcref="anonymous_string#textrange(from=26;0,to=26;55)" xml:id="omdoc1.theory1.axiom11.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="thisfastry">thisfastry</definiendum>gasdg</text></p>
       </CMP>
     </axiom>
     <symbol name="ffss" xml:id="ffss.def.sym"/>
-    <example about="#omdoc1.theory1.example13" stex:srcref="Literal String \documentc#textrange(from=29;1,to=31;15)" xml:id="omdoc1.theory1.example13">
-      <CMP about="#omdoc1.theory1.example13.CMP1" stex:srcref="Literal String \documentc#textrange(from=30;0,to=30;43)" xml:id="omdoc1.theory1.example13.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example13.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=30;0,to=30;43)" xml:id="omdoc1.theory1.example13.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="ffss">ffss</definiendum></text></p>
+    <example about="#omdoc1.theory1.example13" stex:srcref="anonymous_string#textrange(from=29;1,to=31;15)" xml:id="omdoc1.theory1.example13">
+      <CMP about="#omdoc1.theory1.example13.CMP1" stex:srcref="anonymous_string#textrange(from=30;0,to=30;43)" xml:id="omdoc1.theory1.example13.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example13.CMP1.p1" stex:srcref="anonymous_string#textrange(from=30;0,to=30;43)" xml:id="omdoc1.theory1.example13.CMP1.p1"><text class="inlinedef">This is called <definiendum cd="theory1" name="ffss">ffss</definiendum></text></p>
       </CMP>
     </example>
     <symbol name="asd-fasd" xml:id="asd-fasd.def.sym"/>
-    <example about="#omdoc1.theory1.example15" stex:srcref="Literal String \documentc#textrange(from=33;1,to=35;15)" xml:id="omdoc1.theory1.example15">
-      <CMP about="#omdoc1.theory1.example15.CMP1" stex:srcref="Literal String \documentc#textrange(from=33;1,to=33;18)" xml:id="omdoc1.theory1.example15.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example15.CMP1.p1" stex:srcref="Literal String \documentc#textrange(from=33;1,to=33;18)" xml:id="omdoc1.theory1.example15.CMP1.p1">nothign <text class="inlinedef">This is called <definiendum cd="theory1" name="asd-fasd">asd fasd</definiendum></text></p>
+    <example about="#omdoc1.theory1.example15" stex:srcref="anonymous_string#textrange(from=33;1,to=35;15)" xml:id="omdoc1.theory1.example15">
+      <CMP about="#omdoc1.theory1.example15.CMP1" stex:srcref="anonymous_string#textrange(from=33;1,to=33;18)" xml:id="omdoc1.theory1.example15.CMP1">
+        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#omdoc1.theory1.example15.CMP1.p1" stex:srcref="anonymous_string#textrange(from=33;1,to=33;18)" xml:id="omdoc1.theory1.example15.CMP1.p1">nothign <text class="inlinedef">This is called <definiendum cd="theory1" name="asd-fasd">asd fasd</definiendum></text></p>
       </CMP>
     </example>
   </theory>


### PR DESCRIPTION
Revived the 00_cds.t with this PR.

Question for @tkw1536 : why did the locator details change? 
 * the `anonymous_string` change I understand, and is harmless
 * the change in CMP1's `line;column` numbers seems more important, and may be inaccurate -- i haven't had the time to stare it down w.r.t the tex source.